### PR TITLE
Add sanity checks for bounds, and convert from SW & NE to W, S, E, N

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,35 @@
 # TilejsonTester
 Web Interface for creating and testing tilejson files
 
-Try it at http://trailbehind.github.io/TilejsonTester/
+Try it at [http://trailbehind.github.io/TilejsonTester/](http://trailbehind.github.io/TilejsonTester/)
+
+It imports tiles from the URL you specify, and displays the results on a map, so you can judge if it will display properly.
+
+The tester does some sanity checking on the bounds (the west bound must be less than the east, and the south must be less than the north.) 
+In addition, the tester draws a rectangle around the bounds on the map so you can be sure that all tiles are entirely included.
+
+## To work on this app...
+
+It's straightforward to develop this app further on your local machine. 
+The process uses [browser-sync](https://browsersync.io/#install). 
+The command below installs `browser-sync` on your computer. 
+Installing it globally (with "-g") means that you can use it in many different projects, 
+so you only need to do it once.
+
+```
+npm install -g browser-sync		
+```
+
+Next, clone the git repository to your local disk. Then `cd` to the repository's directory, and run `browser-sync`.
+
+It starts a local web server, finds the `index.html` file, and displays it in your browser. 
+When you save changes to files, 
+it automatically updates the browser window. To use it:
+
+```
+git clone https://github.com/trailbehind/TilejsonTester.git
+
+cd TilejsonTester
+
+browser-sync start --server --files "*.html"
+```

--- a/index.html
+++ b/index.html
@@ -38,6 +38,16 @@
             ['$scope', '$location', 'leafletData', 
             function($scope ,  $location ,  leafletData) {
                 angular.extend($scope, {
+                    paths:  {
+                        boundingbox: {
+                            type: 'rectangle',
+                            color: 'grey',
+                            weight: 1,
+                            fillColor: '#f5f5f5',
+                            latlngs: [ { lat: 0, lng: 0 }, { lat: 0, lng: 0 } ],
+                            clickable: false
+                        } 
+                    },
                     center: {
                         lat: 0,
                         lng: 0,
@@ -83,7 +93,6 @@ $scope.updateLayer = function() {
                 "scheme": "xyz",
                 "minzoom": 0,
                 "maxzoom": 11,
-                "maxzoom": 22,
                 "bounds": [-180, -90, 180, 90],
             };
             angular.extend(layerdef, $scope.tilejson);
@@ -108,6 +117,11 @@ $scope.updateLayer = function() {
             }
             $scope.tilejsonLayer = L.tileLayer(layerdef.tiles[0], layerdef);
             map.addLayer($scope.tilejsonLayer);
+            // and draw a box around the map's bounds
+            $scope.paths.boundingbox.latlngs[0].lat = $scope.tilejson.bounds[1];
+            $scope.paths.boundingbox.latlngs[0].lng = $scope.tilejson.bounds[0];
+            $scope.paths.boundingbox.latlngs[1].lat = $scope.tilejson.bounds[3];
+            $scope.paths.boundingbox.latlngs[1].lng = $scope.tilejson.bounds[2];
         }
     });
 };
@@ -120,7 +134,7 @@ $scope.downloadJson = function() {
 };
 
 function handleFileSelect(evt) {
-    console.log(evt);
+    // console.log(evt);
     var files = evt.target.files;
     for (var i = 0, f; f = files[i]; i++) {
         var reader = new FileReader();
@@ -137,7 +151,6 @@ function handleFileSelect(evt) {
     }
     document.getElementById('files').value = null;
 }
-
 document.getElementById('files').addEventListener('change', handleFileSelect, false);
 
 } ]);
@@ -237,7 +250,7 @@ function toUser(object) {
                     </select>
                 </div>
                 <div class="form-group">
-                    <label>Zoom</label>
+                    <label>Zoom</label> (between 0 and 22)
                     <div>
                         <input type="number" min="0" max="22" step="1" ng-model="tilejson.minzoom" />
                         -
@@ -248,10 +261,14 @@ function toUser(object) {
                     <label>URL</label><input class="form-control" type="url" ng-model="tilejson.tiles[0]" size="40" />
                 </div>
                 <div class="form-group">
-                    <label>Bounds</label>
+                    <label>West, South, East, North Bounds</label> (Defaults are OK)
+                    <div ng-show="tilejson.bounds[0]>=tilejson.bounds[2]" style="color:red">West must be less than East</div>
+                    <div ng-show="tilejson.bounds[1]>=tilejson.bounds[3]" style="color:red">South must be less than North</div>
                     <div>
-                    SW <input class="latlon" type="number" min="-90" max="90" step="any" ng-model="tilejson.bounds[1]" />,<input class="latlon" type="number" min="-180" max="180" step="any" ng-model="tilejson.bounds[0]" /> 
-                    NE <input class="latlon" type="number" min="-90" max="90" step="any" ng-model="tilejson.bounds[3]" />,<input class="latlon" type="number" min="-180" max="180" step="any" ng-model="tilejson.bounds[2]" />
+                    W <input class="latlon" type="number" min="-180" max="180" step="any" ng-model="tilejson.bounds[0]" /> 
+                    S <input class="latlon" type="number" min="-90" max="90" step="any" ng-model="tilejson.bounds[1]" />,
+                    E <input class="latlon" type="number" min="-180" max="180" step="any" ng-model="tilejson.bounds[2]" />
+                    N <input class="latlon" type="number" min="-90" max="90" step="any" ng-model="tilejson.bounds[3]" />,
                     </div>
                 </div>
                 <div class="form-group">
@@ -265,7 +282,7 @@ function toUser(object) {
             </form>
         </div>
         <div style="height:100%" class="col-md-8">
-            <leaflet defaults="defaults" width="100%" height="100%" center="center" controls="controls"></leaflet>
+            <leaflet defaults="defaults" width="100%" paths="paths" height="100%" center="center" controls="controls"></leaflet>
         </div>
     </div>
 </div>


### PR DESCRIPTION
I had a problem attempting to import a TileJSON file into GaiaGPS. Not only was I frustrated (and beginning to think that GaiaGPS doesn't work), but I wasted a bunch of your support people's time (request 73418). The problem turned out to be my mistake: I had entered incorrect values for the bounds. Since GaiaGPS appears to honor these bounds, my map wasn't working.

SO... I always like to think about how I could have avoided the problem in the first place. Since I'm a techie, I was able to make the following changes:

1. Change the **bounds** from "SW" and "NE" to West, South, East, North. (I find it much easier to think about edges than composite points. This also matches the order of the values in the TileJSON file.)
2. Add tests to ensure that W bound < E bound, and S bound < N bound. The test page shows a warning when a bound violates the tests. (This alone would have saved my bacon.)
3. Tweak the **Zoom** legend to indicate the legal range of values. 
4. Use the WSEN bounds to draw a rectangle on the map. This lets the viewer be sure the tiles are completely enclosed by those bounds. (I also had entered incorrect values for the bounds and only some of the tiles were visible.)
5. Add instructions to the README.md file for using `browser-sync` to develop locally.

I hope this is helpful. Thanks for a great tool (TilejsonTester) and app (GaiaGPS). 